### PR TITLE
[fix] : org 레포에서 sync될 때 CI 실행 제외

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: |
-      github.repository == 'Kimxxunu/2025_SEASONTHON_TEAM_10_BE' ||
-      github.repository == 'wnd01jun/2025_SEASONTHON_TEAM_10_BE'
+      (github.repository == 'Kimxxunu/2025_SEASONTHON_TEAM_10_BE' || 
+       github.repository == 'wnd01jun/2025_SEASONTHON_TEAM_10_BE') &&
+      github.actor != 'web-flow' &&
+      github.actor != 'dependabot[bot]'
 
     steps:
       - name: 코드 체크아웃


### PR DESCRIPTION
- org 레포(9oormthon-univ:main) → 내 레포(main) 동기화 시
  불필요하게 CI/CD가 중복 실행되는 문제 수정
- github.actor 조건을 추가하여 web-flow 등의 자동 sync push는 배포에서 제외