### PR TITLE
[Refactor]Recipe 조회수 반영 로직 개선

### DIFF
--- a/api-user/src/main/kotlin/zipbap/user/api/recipe/event/RecipeViewCountListener.kt
+++ b/api-user/src/main/kotlin/zipbap/user/api/recipe/event/RecipeViewCountListener.kt
@@ -1,0 +1,20 @@
+package zipbap.user.api.recipe.event
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import zipbap.global.domain.recipe.RecipeRepository
+
+@Component
+class RecipeViewCountListener(
+        private val recipeRepository: RecipeRepository
+) {
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun onRecipeViewed(event: RecipeViewedEvent) {
+        recipeRepository.updateViewCount(event.recipeId)
+    }
+}

--- a/api-user/src/main/kotlin/zipbap/user/api/recipe/event/RecipeViewedEvent.kt
+++ b/api-user/src/main/kotlin/zipbap/user/api/recipe/event/RecipeViewedEvent.kt
@@ -1,0 +1,6 @@
+package zipbap.user.api.recipe.event
+
+data class RecipeViewedEvent(
+        val recipeId: String,
+        val viewerUserId: Long
+)

--- a/global/build.gradle.kts
+++ b/global/build.gradle.kts
@@ -45,8 +45,8 @@ dependencyManagement {
         // ⚠️ JDBC 드라이버는 애플리케이션 모듈(api-*)에 두는 걸 권장. (여기선 뺌)
 
         // Querydsl (APT는 여기서!)
-        implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
-        kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+        implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+        kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
         kapt("jakarta.annotation:jakarta.annotation-api")
         kapt("jakarta.persistence:jakarta.persistence-api")
 

--- a/global/src/main/kotlin/zipbap/global/domain/recipe/RecipeRepository.kt
+++ b/global/src/main/kotlin/zipbap/global/domain/recipe/RecipeRepository.kt
@@ -1,6 +1,7 @@
 package zipbap.global.domain.recipe
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
@@ -35,4 +36,10 @@ interface RecipeRepository : JpaRepository<Recipe, String> {
 
     // ✅ 여기만 남기면 됨
     fun findAllByMyCategoryId(myCategoryId: String): List<Recipe>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Recipe r SET r.viewCount = r.viewCount + 1 WHERE r.id = :recipeId
+    """)
+    fun updateViewCount(@Param("recipeId") recipeId: String): Unit
 }


### PR DESCRIPTION
### 연관 이슈
---
#35 
### 개선된 점
---
- 레시피 상세 조회시(api/recipes/detail/{recipeId}) 조회수 상승 로직을 dirty checking방식에서 -> EventListener 기반 원자성 쿼리로 개선
### 추가사항
---
- Jmeter 테스트 결과(Thread=20,Ramp-up=1,loop=3 기준 total 60) 기존 조회수 55개 -> 60개 상승 확인 
- console에서 경합으로 인해 발생하던 exception 발생 x
- 자세항 사항은 https://wnd01jun.tistory.com/44 참고해주세요

